### PR TITLE
Fix data center host unique validation

### DIFF
--- a/eoncloud_web/biz/idc/views.py
+++ b/eoncloud_web/biz/idc/views.py
@@ -125,4 +125,12 @@ def is_host_unique(request):
 
     host = request.query_params['host']
 
-    return Response(not DataCenter.objects.filter(host=host).exists())
+    pk = request.query_params['id']
+
+    queryset = DataCenter.objects.filter(host=host)
+
+    # If pk is not empty, then user must be editing other than creating a data center
+    if pk:
+        queryset = queryset.exclude(pk=pk)
+
+    return Response(not queryset.exists())

--- a/eoncloud_web/render/static/management/app.js
+++ b/eoncloud_web/render/static/management/app.js
@@ -170,6 +170,7 @@ CloudApp.factory("BoxService", function(){
 CloudApp.factory('ValidationTool', function(){
 
     var defaultConfig = {
+        onkeyup: false,
         doNotHideMessage: true,
         errorElement: 'span',
         errorClass: 'help-block',

--- a/eoncloud_web/render/static/management/controllers/data_center_ctrl.js
+++ b/eoncloud_web/render/static/management/controllers/data_center_ctrl.js
@@ -132,7 +132,7 @@ CloudApp.controller('DataCenterController',
     .controller('DataCenterCreateController',
         function($rootScope, $scope, $modalInstance,
                  data_center_table, data_center, DataCenterForm,
-                 $i18next, CommonHttpService, ToastrService){
+                 $i18next, CommonHttpService, ResourceTool, ToastrService){
 
             $scope.data_center = data_center;
 
@@ -150,7 +150,7 @@ CloudApp.controller('DataCenterController',
                     return;
                 }
 
-                data_center = angular.copy(data_center);
+                data_center = ResourceTool.copy_only_data(data_center);
 
                 var url = '/api/data-centers';
 
@@ -189,7 +189,13 @@ CloudApp.controller('DataCenterController',
                         host: {
                             required: true,
                             ip: true,
-                            remote: "/api/data-centers/is-host-unique"
+                            remote: {
+                                url: "/api/data-centers/is-host-unique",
+                                data: {
+                                    id: $("#id").val()
+                                },
+                                async: false
+                            }
                         },
                         project: {
                             required: true,

--- a/eoncloud_web/render/static/management/views/data_center.html
+++ b/eoncloud_web/render/static/management/views/data_center.html
@@ -87,7 +87,7 @@
     </div>
     <div class="modal-body">
         <form id="dataCenterForm" role="form" class="form-horizontal form-bordered">
-            <input type="hidden"  name="id" data-ng-model="data_center.id">
+            <input type="hidden" id="id" name="id" value="{[{ data_center.id }]}">
             <div class="form-group">
                 <label class="col-md-3 control-label" for="name">{[{ 'data_center.name' | i18next }]} </label>
                 <div class="col-md-5">


### PR DESCRIPTION
Fix data center host validation bug when editing data center

Previously, when edit a data center, host unique validation will check take account of  the current data center, in that case, unique validation will fail if user don't change host to another one.

After this fix, when edit a data center, host unique check will escape the current data center.
