### PR TITLE
 Fix bug: data center table display dirty data

### DIFF
--- a/eoncloud_web/render/static/management/controllers/data_center_ctrl.js
+++ b/eoncloud_web/render/static/management/controllers/data_center_ctrl.js
@@ -134,7 +134,7 @@ CloudApp.controller('DataCenterController',
                  data_center_table, data_center, DataCenterForm,
                  $i18next, CommonHttpService, ResourceTool, ToastrService){
 
-            $scope.data_center = data_center;
+            $scope.data_center = ResourceTool.copy_only_data(data_center);
 
             $modalInstance.opened.then(function() {
                 setTimeout(DataCenterForm.init, 0)
@@ -149,8 +149,6 @@ CloudApp.controller('DataCenterController',
                 if(!$("#dataCenterForm").validate().form()){
                     return;
                 }
-
-                data_center = ResourceTool.copy_only_data(data_center);
 
                 var url = '/api/data-centers';
 


### PR DESCRIPTION
 Previouly, when user changed data center values and didn't submit these
 changes, data center table would wrongly display these changes. This
 bug is caused by angularjs data binding, now when user edit a data center, the
 data will be copied.
