### PR TITLE
Account app migration

### DIFF
--- a/eoncloud_web/biz/account/migrations/0003_auto_20150703_1652.py
+++ b/eoncloud_web/biz/account/migrations/0003_auto_20150703_1652.py
@@ -1,0 +1,73 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import django.utils.timezone
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('auth', '0001_initial'),
+        ('account', '0002_delete_contract_user_unique'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='UserProxy',
+            fields=[
+            ],
+            options={
+                'proxy': True,
+            },
+            bases=('auth.user',),
+        ),
+        migrations.AddField(
+            model_name='contract',
+            name='create_date',
+            field=models.DateTimeField(default=django.utils.timezone.now, verbose_name='Create Date', auto_now_add=True),
+            preserve_default=False,
+        ),
+        migrations.AddField(
+            model_name='contract',
+            name='update_date',
+            field=models.DateTimeField(default=django.utils.timezone.now, auto_now=True, auto_now_add=True, verbose_name='Update Date'),
+            preserve_default=False,
+        ),
+        migrations.AddField(
+            model_name='quota',
+            name='update_date',
+            field=models.DateTimeField(default=django.utils.timezone.now, auto_now=True, auto_now_add=True, verbose_name='Update Date'),
+            preserve_default=False,
+        ),
+        migrations.AlterField(
+            model_name='contract',
+            name='id',
+            field=models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True),
+            preserve_default=True,
+        ),
+        migrations.AlterField(
+            model_name='operation',
+            name='id',
+            field=models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True),
+            preserve_default=True,
+        ),
+        migrations.AlterField(
+            model_name='operation',
+            name='resource',
+            field=models.CharField(max_length=128, verbose_name='Resource'),
+            preserve_default=True,
+        ),
+        migrations.AlterField(
+            model_name='quota',
+            name='create_date',
+            field=models.DateTimeField(auto_now_add=True, verbose_name='Create Date'),
+            preserve_default=True,
+        ),
+        migrations.AlterField(
+            model_name='quota',
+            name='id',
+            field=models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True),
+            preserve_default=True,
+        ),
+    ]

--- a/eoncloud_web/biz/account/settings.py
+++ b/eoncloud_web/biz/account/settings.py
@@ -44,6 +44,7 @@ RESOURCE_ACTION_CHOICES = (
     ("launch", _("launch")),
     ("create", _("create")),
     ("update", _("update")),
+    ("delete", _("delete")),
     ("attach_router", _("attach router")),
     ("detach_router", _("detach router")),
 )


### PR DESCRIPTION
```
1. Add create_date, update_date fields to Contract model;
2. Use auto_now_add to replace default value of create_date
field of Quota;
3. Add update_date field to Quota model;
4. Remove choices parameter of resource fielf of Operation Model;
5. Changed delete_contracts, update_quotas in account.views;
6. add 'delete' item to RESOURCE_ACTION_CHOICES in account.settings;
7. Remove redundant id declaration;
8. Change operation user when admin create, update and delete
contract/quotas.
```
