### PR TITLE
Fix Flavor list api bug

### DIFF
--- a/eoncloud_web/biz/instance/views.py
+++ b/eoncloud_web/biz/instance/views.py
@@ -41,6 +41,10 @@ class FlavorList(generics.ListCreateAPIView):
     queryset = Flavor.objects.all()
     serializer_class = FlavorSerializer
 
+    def list(self, request):
+        serializer = self.serializer_class(self.get_queryset(), many=True)
+        return Response(serializer.data)
+
 
 class FlavorDetail(generics.RetrieveUpdateDestroyAPIView):
     queryset = Flavor.objects.all()

--- a/eoncloud_web/eoncloud_web/settings.py
+++ b/eoncloud_web/eoncloud_web/settings.py
@@ -62,8 +62,6 @@ MIDDLEWARE_CLASSES = (
 )
 
 REST_FRAMEWORK = {
-    "PAGE_SIZE": 10,
-    "PAGE_SIZE_QUERY_PARAM": "page_size",
     'DEFAULT_AUTHENTICATION_CLASSES': (
         'rest_framework.authentication.SessionAuthentication',
         'rest_framework.authentication.BasicAuthentication'


### PR DESCRIPTION
1. Remove pagination configuration from REST_FRAMEWORK in settings.py, this configuration
   may cause list api based on django rest plugin to return different data.
2. Changed FlavorList in biz/instance/views.py to make sure it always
   return array.
